### PR TITLE
Change setup.py according to PyPI and bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.1.0'
+version = '0.1.3'
 
 REQUIREMENTS = [
     'python-dateutil',
@@ -8,7 +8,7 @@ REQUIREMENTS = [
 ]
 
 setup(
-    name='python-shopify-api',
+    name='python-shopify',
     version=version,
     packages=find_packages(),
     url='https://github.com/ziplokk1/python-shopify-api',


### PR DESCRIPTION
According to deploy to https://pypi.python.org/pypi/python-shopify/

- change the name to `python-shopify` to allow `pip install python-shopify`
- bump version 
- @ziplokk1 added as Owner of PyPI index package
- `python setup.py sdist upload` will release new versions